### PR TITLE
Introduce Manual Release Pipeline for DockerHub Deployment and GitHub Releases

### DIFF
--- a/.github/workflows/housekeeping-issues.yml
+++ b/.github/workflows/housekeeping-issues.yml
@@ -1,13 +1,9 @@
 ---
-# @file housekeeping-issues.yml
-# @brief Github Actions workflow handles the automatic assignment of newly created issues and pull requests.
-#
-# @description The workflow, that is called this way, handles the automatic assignment of newly
-# created issues and pull requests to specific projects and users. By leveraging this workflow,
-# tasks and contributions are efficiently tracked and assigned, ensuring clear ownership and
-# streamlined collaboration within your development projects. It is designed to automatically
-# trigger whenever new issues or Pull Requests are created.
-
+## Github Actions workflow, that handles the automatic assignment of newly created issues and pull
+## requests to specific projects and users. By leveraging this workflow, tasks and contributions are
+## efficiently tracked and assigned, ensuring clear ownership and streamlined collaboration within
+## your development projects. It is designed to automatically trigger whenever new issues or Pull
+## Requests are created.
 
 name: "Housekeeping: Issues + PRs"
 

--- a/.github/workflows/housekeeping-labels.yml
+++ b/.github/workflows/housekeeping-labels.yml
@@ -1,14 +1,10 @@
 ---
-# @file housekeeping-labels.yml
-# @brief Github Actions workflow that ensures all mandatory labels are present for a repo and all obsolete labels are removed.
-#
-# @description The workflow, that is called this way, is responsible for deleting unnecessary
-# labels and creating the required labels for issues and pull requests. By executing this workflow,
-# it ensures a streamlined and organized labeling system, enabling effective categorization and
-# tracking of tasks and contributions within your projects. Since the labels are managed through
-# this workflow, the settings from link:https://github.com/organizations/sommerfeld-io/settings/repository-defaults[GitHub organizations label-config]
-# don't take effect.
-
+## Github Actions workflow, that is responsible for deleting unnecessary labels and creating the
+## required labels for issues and pull requests. By executing this workflow, it ensures a
+## streamlined and organized labeling system, enabling effective categorization and tracking of
+## tasks and contributions within your projects. Since the labels are managed through this workflow,
+## the settings from link:https://github.com/organizations/sommerfeld-io/settings/repository-defaults[GitHub organizations label-config]
+## don't take effect.
 
 name: "Housekeeping: Labels"
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -96,7 +96,7 @@ jobs:
 
   docs:
     runs-on: ubuntu-latest
-    if: ${{ (github.actor != 'dependabot[bot]') && (github.ref == 'refs/heads/main') }}
+    if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       contents: write
     steps:
@@ -160,6 +160,7 @@ jobs:
 
   build-image:
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
     name: ${{ matrix.image-name }}:${{ github.sha }}
     needs: [
       'docs',
@@ -235,6 +236,7 @@ jobs:
 
   test-image:
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
     name: ${{ matrix.image-name }}
     needs: ['build-image']
     permissions:
@@ -258,9 +260,9 @@ jobs:
 
   publish-rc:
     runs-on: ubuntu-latest
+    if: ${{ (github.actor != 'dependabot[bot]') && (github.ref == 'refs/heads/main') }}
     name: ${{ matrix.image-name }} as release candidate
     needs: ['test-image']
-    if: ${{ (github.actor != 'dependabot[bot]') && (github.ref == 'refs/heads/main') }}
     permissions: # see build-image (duplicated because github actions does not support anchors)
       contents: read
       pull-requests: write

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,25 +1,21 @@
 ---
-# @file pipeline.yml
-# @brief Deployment pipeline for the source2docs-website.
-#
-# @description The deployment pipeline for the source2docs-website is implemented using GitHub
-# Actions. The primary objective of this pipeline is to assess the releasability of the application
-# for deployment with every push to the ``main`` branch. This is achieved through a series of
-# automated tests and validations (performed on all branches, but the ``main`` branch carries the
-# code thatshould be stable and production-ready). The workflow is designed to build every artifact
-# of the source2docs-website and subject it to various types of tests to verify its functionality
-# and integrity. If all tests are successful, indicating that the project is ready for release, a
-# release candidate is generated and published to DockerHub.
-#
-# The deployment process for the source2docs-website utilizes Docker images. Images are built and
-# unit tested. Each Snapshot image is tagged with the commit-sha, providing a clear reference to
-# the version of the codebase from which it was generated, and subsequently pushed to DockerHub.
-# Following this initial deployment, the Snapshot Docker images undergo further testing (security,
-# performance, acceptance, etc.) to assess their performance and stability. If these additional
-# tests pass successfully (and the workflow is running on the ``main`` branch), indicating that the
-# Snapshot image is robust and reliable, it is then tagged as a release candidate. Notably, release
-# candidates are exclusively published from the ``main`` branch.
-
+## The deployment pipeline for the krokidile app is implemented using GitHub Actions. The primary
+## objective of this pipeline is to assess the releasability of the application for deployment with
+## every push to the `main` branch. This is achieved through a series of automated tests and
+## validations (performed on all branches, but the `main` branch carries the code that should be
+## stable and production-ready). The workflow is designed to build every artifact of the krokidile
+## app and subject it to various types of tests to verify its functionality and integrity. If all
+## tests are successful, indicating that the project is ready for release, a release candidate is
+## generated and published to DockerHub.
+##
+## The deployment process for the krokidile app utilizes Docker images. Images are built and
+## unit tested. Each Snapshot image is tagged with the commit-sha, providing a clear reference to
+## the version of the codebase from which it was generated, and subsequently pushed to DockerHub.
+## Following this initial deployment, the Snapshot Docker images undergo further testing (security,
+## performance, acceptance, etc.) to assess their performance and stability. If these additional
+## tests pass successfully (and the workflow is running on the `main` branch), indicating that the
+## Snapshot image is robust and reliable, it is then tagged as a release candidate. Notably, release
+## candidates are exclusively published from the `main` branch.
 
 name: Build + Deployment Pipeline
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         run: npm install --save-dev standard-version
         shell: bash
       - name: standard-version - Run to determine the version and create a tag
-        run: npx standard-version 
+        run: npx standard-version
         shell: bash
       - name: Info - git tags
         run: git tag
@@ -48,4 +48,3 @@ jobs:
       # TODO revert antora.yml from bash (sed)
 
   # TODO dockerhub in a matrix
-  

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+---
+##
+##
+##
+
+name: Release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    # TODO if main and not dependabot
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Info - files to be bumped (see .versionrc.json)
+        run: cat docs/antora.yml
+        shell: bash
+      - name: Install Node.js
+        uses: actions/setup-node@v4.0.2
+        with:
+          node-version: 22.2.0
+      - name: standard-version - Install
+        run: npm install --save-dev standard-version
+        shell: bash
+      - name: standard-version - Run to determine the version and create a tag
+        run: npx standard-version 
+        shell: bash
+      - name: Info - git tags
+        run: git tag
+        shell: bash
+      - name: Info - bumped files (see .versionrc.json)
+        run: cat docs/antora.yml
+        shell: bash
+      # - name: GitHub release
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GH_TOKEN_REPO_AND_PROJECT }}
+      #   run: |
+      #     git push --follow-tags
+      #     VERSION=$(git describe --tags $(git rev-list --tags --max-count=1))
+      #     gh release create $VERSION --generate-notes
+      #   shell: bash
+      # TODO revert antora.yml from bash (sed)
+
+  # TODO dockerhub in a matrix
+  

--- a/.ls-lint.yml
+++ b/.ls-lint.yml
@@ -13,8 +13,9 @@ ls:
   .yaml: kebab-case
   .feature: kebab-case
 
-  .sh: kebab-case
+  .java: PascalCase
   .kt: PascalCase
+  .sh: kebab-case
 
   .css: kebab-case
   .html: kebab-case
@@ -24,13 +25,14 @@ ls:
 
   Dockerfile: PascalCase
   Vagrantfile: PascalCase
-  Jenkinsfile: PascalCase
 
+  .babelrc: lowercase
   .env: lowercase
+  .dockerignore: lowercase
   .folderslintrc: lowercase
-  .shellcheckrc: lowercase
   .gitignore: lowercase
   .gitkeep: lowercase
+  .shellcheckrc: lowercase
 
 ignore:
   - docs/ui-bundle/.gulp.json
@@ -45,8 +47,9 @@ ignore:
   - .gitpod.yml
   - target
 
-  # linter definitions
+  # linter definitions etc.
   - .hadolint.yml
   - .ls-lint.yml
   - .pre-commit-config.yaml
   - .yamllint.yml
+  - .versionrc.json

--- a/.versionrc.json
+++ b/.versionrc.json
@@ -1,0 +1,9 @@
+{
+  "bumpFiles": [
+    {
+      "filename": "docs/antora.yml",
+      "type": "yaml"
+    }
+  ]
+}
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "krokidile",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "krokidile",
-      "version": "1.0.0",
+      "version": "0.0.0",
       "license": "ISC",
       "dependencies": {
         "react": "^18.3.1",
@@ -3727,20 +3727,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "krokidile",
-  "version": "main",
+  "version": "0.0.0",
   "main": "index.js",
   "directories": {
     "doc": "docs"


### PR DESCRIPTION
This pull request introduces a new release pipeline that is triggered manually to streamline the deployment process of our Docker images and manage versioning and releases on GitHub. The key features of this pipeline include:

1. **Manual Trigger:** The pipeline is designed to be triggered manually, providing control over the timing of releases.
2. **DockerHub Deployment:** Upon triggering, the pipeline builds and pushes Docker images to DockerHub, ensuring that our images are always up-to-date and readily available.
3. **Version Management:** The pipeline leverages standard-version to automatically determine the next semantic version based on the commits since the last release.
4. **GitHub Releases:** After determining the new version, the pipeline tags the repository and creates a new GitHub release, including the release notes generated by standard-version.