### PR TITLE
feat: syntax highlighting for plantuml

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,7 +1,7 @@
 ---
 name: public
 title: krokidile
-version: main
+version: monaco-plantuml
 start_page: ROOT:index.adoc
 nav:
   - modules/ROOT/nav.adoc

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT License",
       "dependencies": {
+        "@sinm/monaco-plantuml": "^0.5.6",
         "bootstrap": "^5.3.3",
         "buffer": "^6.0.3",
         "jquery": "^3.7.1",
@@ -3669,6 +3670,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@sinm/monaco-plantuml": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@sinm/monaco-plantuml/-/monaco-plantuml-0.5.6.tgz",
+      "integrity": "sha512-YVwxF/wug5g+fYBn8qxDfifh0TPymXvuUxjWBe9vIxwR3sZq2kU1tv5Z4Iyma+RiWKr0Fz7qCDdyQf8FGUVxTw==",
+      "dependencies": {
+        "dexie": "^3.2.2",
+        "lodash": "^4.17.21",
+        "monaco-editor": "*",
+        "ohm-js": "^16.4.0"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -6115,6 +6127,14 @@
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "dev": true
+    },
+    "node_modules/dexie": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dexie/-/dexie-3.2.7.tgz",
+      "integrity": "sha512-2a+BXvVhY5op+smDRLxeBAivE7YcYaneXJ1la3HOkUfX9zKkE/AJ8CNgjiXbtXepFyFmJNGSbmjOwqbT749r/w==",
+      "engines": {
+        "node": ">=6.0"
+      }
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -9199,8 +9219,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash-es": {
       "version": "4.17.21",
@@ -13636,6 +13655,14 @@
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
       "dev": true
+    },
+    "node_modules/ohm-js": {
+      "version": "16.6.0",
+      "resolved": "https://registry.npmjs.org/ohm-js/-/ohm-js-16.6.0.tgz",
+      "integrity": "sha512-X9P4koSGa7swgVQ0gt71UCYtkAQGOjciJPJAz74kDxWt8nXbH5HrDOQG6qBDH7SR40ktNv4x61BwpTDE9q4lRA==",
+      "engines": {
+        "node": ">=0.12.1"
+      }
     },
     "node_modules/on-finished": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "license": "MIT License",
   "description": "Krokidile is a web-based Live-Editor for Diagrams to use with Kroki.io.",
   "dependencies": {
+    "@sinm/monaco-plantuml": "^0.5.6",
     "bootstrap": "^5.3.3",
     "buffer": "^6.0.3",
     "jquery": "^3.7.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import * as monaco from 'monaco-editor';
+import { PUmlExtension } from '@sinm/monaco-plantuml';
 import 'bootstrap';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import './custom.scss';
@@ -19,6 +20,9 @@ const editor = monaco.editor.create(document.getElementById('editor'), {
   language: 'plantuml',
   theme: 'vs-dark',
 });
+
+const extension = new PUmlExtension();
+const disposer = extension.active(editor);
 
 //
 // Get the diagram code from the editor and send it to the Kroki service.


### PR DESCRIPTION
This pull request introduces syntax highlighting support for PlantUML in the Monaco Editor. This enhancement will significantly improve the user experience for developers working with PlantUML diagrams within our application.

With these changes, developers can now enjoy a more readable and visually appealing interface when creating and editing PlantUML diagrams. This should also aid in reducing potential syntax errors and improve overall productivity.

fixes #45