### PR TITLE
feat: Download Diagram as SVG or PNG + Download and Upload Diagram Code

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,7 +1,7 @@
 ---
 name: public
 title: krokidile
-version: main
+version: download-images-and-sources
 start_page: ROOT:index.adoc
 nav:
   - modules/ROOT/nav.adoc

--- a/src/index.html
+++ b/src/index.html
@@ -35,6 +35,8 @@
 
           <div id="main-nav"></div>
           <hr />
+          <div id="actions-menu"></div>
+          <hr />
           <div id="external-nav"></div>
           <hr />
           <div id="meta-nav"></div>

--- a/src/index.js
+++ b/src/index.js
@@ -110,7 +110,7 @@ function downloadCode() {
   const diagramCode = editor.getValue();
   const blob = new Blob([diagramCode], { type: 'text/plain' });
   const url = URL.createObjectURL(blob);
-  triggerDownload(url, fileName)
+  triggerDownload(url, fileName);
 }
 
 //
@@ -125,7 +125,7 @@ function downloadSvg() {
     .then((svgResult) => {
       const blob = new Blob([svgResult], { type: 'image/svg+xml' });
       const url = URL.createObjectURL(blob);
-      triggerDownload(url, fileName)
+      triggerDownload(url, fileName);
     })
     .catch((error) => {
       console.error('Error:', error);
@@ -143,7 +143,7 @@ function downloadPng() {
     .then((response) => response.blob())
     .then((pngResult) => {
       const url = URL.createObjectURL(pngResult);
-      triggerDownload(url, fileName)
+      triggerDownload(url, fileName);
     })
     .catch((error) => {
       console.error('Error:', error);

--- a/src/index.js
+++ b/src/index.js
@@ -110,10 +110,7 @@ function downloadCode() {
   const diagramCode = editor.getValue();
   const blob = new Blob([diagramCode], { type: 'text/plain' });
   const url = URL.createObjectURL(blob);
-  const link = document.createElement('a');
-  link.href = url;
-  link.download = fileName;
-  link.click();
+  triggerDownload(url, fileName)
 }
 
 //
@@ -128,10 +125,7 @@ function downloadSvg() {
     .then((svgResult) => {
       const blob = new Blob([svgResult], { type: 'image/svg+xml' });
       const url = URL.createObjectURL(blob);
-      const link = document.createElement('a');
-      link.href = url;
-      link.download = fileName;
-      link.click();
+      triggerDownload(url, fileName)
     })
     .catch((error) => {
       console.error('Error:', error);
@@ -149,14 +143,21 @@ function downloadPng() {
     .then((response) => response.blob())
     .then((pngResult) => {
       const url = URL.createObjectURL(pngResult);
-      const link = document.createElement('a');
-      link.href = url;
-      link.download = fileName;
-      link.click();
+      triggerDownload(url, fileName)
     })
     .catch((error) => {
       console.error('Error:', error);
     });
+}
+
+//
+// Trigger the actual download of the file.
+//
+function triggerDownload(url, fileName) {
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = fileName;
+  link.click();
 }
 
 //

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ component Component
 User -right-> Component
 
 @enduml
-`
+`;
 
 //
 // Setup Monaco Editor.
@@ -52,11 +52,8 @@ const disposer = extension.active(editor);
 function encodeDiagramCode(diagramCode) {
   const data = Buffer.from(diagramCode, 'utf8');
   const compressed = pako.deflate(data, { level: 9 });
-  
-  return Buffer.from(compressed)
-    .toString('base64')
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_');
+
+  return Buffer.from(compressed).toString('base64').replace(/\+/g, '-').replace(/\//g, '_');
 }
 
 //
@@ -83,17 +80,22 @@ editor.onDidChangeModelContent(() => {
     });
 });
 
-
 //
 // Render buttons to download sources and images.
 //
 function ActionsMenu() {
-  var buttonStyle = "outline-light"
+  var buttonStyle = 'outline-light';
   return (
     <div class="btn-group" role="group" aria-label="actions-menu">
-      <button type={`button`} className={`btn btn-${buttonStyle}`} onClick={() => downloadCode()}><i className={`bi bi-save`}></i> Code</button>
-      <button type={`button`} className={`btn btn-${buttonStyle}`} onClick={() => downloadSvg()}><i className={`bi bi-save`}></i> SVG</button>
-      <button type={`button`} className={`btn btn-${buttonStyle}`} onClick={() => downloadPng()}><i className={`bi bi-save`}></i> PNG</button>
+      <button type={`button`} className={`btn btn-${buttonStyle}`} onClick={() => downloadCode()}>
+        <i className={`bi bi-save`}></i> Code
+      </button>
+      <button type={`button`} className={`btn btn-${buttonStyle}`} onClick={() => downloadSvg()}>
+        <i className={`bi bi-save`}></i> SVG
+      </button>
+      <button type={`button`} className={`btn btn-${buttonStyle}`} onClick={() => downloadPng()}>
+        <i className={`bi bi-save`}></i> PNG
+      </button>
     </div>
   );
 }
@@ -120,7 +122,7 @@ function downloadCode() {
 function downloadSvg() {
   const fileName = 'diagram.svg';
   const diagramCode = editor.getValue();
-  
+
   fetch(`${KROKI_URL}/plantuml/svg/${encodeDiagramCode(diagramCode)}`)
     .then((response) => response.text())
     .then((svgResult) => {
@@ -142,7 +144,7 @@ function downloadSvg() {
 function downloadPng() {
   const fileName = 'diagram.png';
   const diagramCode = editor.getValue();
-  
+
   fetch(`${KROKI_URL}/plantuml/png/${encodeDiagramCode(diagramCode)}`)
     .then((response) => response.blob())
     .then((pngResult) => {

--- a/src/index.js
+++ b/src/index.js
@@ -162,7 +162,7 @@ function downloadPng() {
 //
 // Shortcut CTRL + s to download diagram code
 //
-document.addEventListener('keydown', function(event) {
+document.addEventListener('keydown', function (event) {
   if (event.ctrlKey && event.key === 's') {
     event.preventDefault();
     downloadCode();

--- a/src/index.js
+++ b/src/index.js
@@ -158,3 +158,13 @@ function downloadPng() {
       console.error('Error:', error);
     });
 }
+
+//
+// Shortcut CTRL + s to download diagram code
+//
+document.addEventListener('keydown', function(event) {
+  if (event.ctrlKey && event.key === 's') {
+    event.preventDefault();
+    downloadCode();
+  }
+});

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,26 @@ const pako = require('pako');
 const Buffer = require('buffer/').Buffer; // note the trailing slash
 
 const KROKI_URL = 'https://kroki.io'; // todo https://github.com/sommerfeld-io/krokidile/issues/41
-const DEFAULT_EDITOR_VALUE = ['@startuml', "' ...", '@enduml'].join('\n');
+// const DEFAULT_EDITOR_VALUE = ['@startuml', "' ...", '@enduml'].join('\n');
+
+const DEFAULT_EDITOR_VALUE = `@startuml
+
+skinparam linetype ortho
+skinparam monochrome false
+skinparam componentStyle uml2
+skinparam backgroundColor transparent
+skinparam activity {
+    'FontName Ubuntu
+    FontName Roboto
+}
+
+actor User
+component Component
+
+User -right-> Component
+
+@enduml
+`
 
 //
 // Setup Monaco Editor.
@@ -28,6 +47,19 @@ const extension = new PUmlExtension();
 const disposer = extension.active(editor);
 
 //
+// Encode the diagram code. Prepare to send to kroki server.
+//
+function encodeDiagramCode(diagramCode) {
+  const data = Buffer.from(diagramCode, 'utf8');
+  const compressed = pako.deflate(data, { level: 9 });
+  
+  return Buffer.from(compressed)
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+}
+
+//
 // Get the diagram code from the editor and send it to the Kroki service.
 // The editor content ist stored in the local storage to make sure the content survives a page
 // reload.
@@ -41,14 +73,7 @@ editor.onDidChangeModelContent(() => {
     return;
   }
 
-  const data = Buffer.from(diagramCode, 'utf8');
-  const compressed = pako.deflate(data, { level: 9 });
-  const encodedDiagramCode = Buffer.from(compressed)
-    .toString('base64')
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_');
-
-  fetch(`${KROKI_URL}/plantuml/svg/${encodedDiagramCode}`)
+  fetch(`${KROKI_URL}/plantuml/svg/${encodeDiagramCode(diagramCode)}`)
     .then((response) => response.text())
     .then((imageResult) => {
       document.getElementById('preview').innerHTML = imageResult;
@@ -57,3 +82,77 @@ editor.onDidChangeModelContent(() => {
       console.error('Error:', error);
     });
 });
+
+
+//
+// Render buttons to download sources and images.
+//
+function ActionsMenu() {
+  var buttonStyle = "outline-light"
+  return (
+    <div class="btn-group" role="group" aria-label="actions-menu">
+      <button type={`button`} className={`btn btn-${buttonStyle}`} onClick={() => downloadCode()}><i className={`bi bi-save`}></i> Code</button>
+      <button type={`button`} className={`btn btn-${buttonStyle}`} onClick={() => downloadSvg()}><i className={`bi bi-save`}></i> SVG</button>
+      <button type={`button`} className={`btn btn-${buttonStyle}`} onClick={() => downloadPng()}><i className={`bi bi-save`}></i> PNG</button>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('actions-menu')).render(<ActionsMenu />);
+
+//
+// Download the contents of the editor as text file.
+//
+function downloadCode() {
+  const fileName = 'code.puml';
+  const diagramCode = editor.getValue();
+  const blob = new Blob([diagramCode], { type: 'text/plain' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = fileName;
+  link.click();
+}
+
+//
+// Download the preview image as SVG.
+//
+function downloadSvg() {
+  const fileName = 'diagram.svg';
+  const diagramCode = editor.getValue();
+  
+  fetch(`${KROKI_URL}/plantuml/svg/${encodeDiagramCode(diagramCode)}`)
+    .then((response) => response.text())
+    .then((svgResult) => {
+      const blob = new Blob([svgResult], { type: 'image/svg+xml' });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = fileName;
+      link.click();
+    })
+    .catch((error) => {
+      console.error('Error:', error);
+    });
+}
+
+//
+// Download the preview image as PNG.
+//
+function downloadPng() {
+  const fileName = 'diagram.png';
+  const diagramCode = editor.getValue();
+  
+  fetch(`${KROKI_URL}/plantuml/png/${encodeDiagramCode(diagramCode)}`)
+    .then((response) => response.blob())
+    .then((pngResult) => {
+      const url = URL.createObjectURL(pngResult);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = fileName;
+      link.click();
+    })
+    .catch((error) => {
+      console.error('Error:', error);
+    });
+}


### PR DESCRIPTION
This pull request introduces several new features to enhance the usability of our diagram editor. These features provide users with more flexibility in how they interact with their diagram code and the resulting visualizations.

- https://github.com/sommerfeld-io/krokidile/issues/47
    - Users can now download the raw diagram code directly from the editor. This feature allows users to easily save and share their work outside of the application. The download is triggered by clicking the 'Code' button in the actions menu.
- https://github.com/sommerfeld-io/krokidile/issues/24
    - In addition to viewing diagrams within the application, users can now export diagrams as SVG or PNG files. This provides more flexibility for users who want to use their diagrams in other applications or contexts. The export is initiated by clicking either the 'SVG' or 'PNG' button in the actions menu.

These features were implemented with careful consideration of the existing user interface and workflows. They are expected to provide significant value to our users, making it easier for them to create, share, and reuse diagrams.

