### PR TITLE
introduce additional diagram types

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,8 @@
     "exitcode",
     "krokidile",
     "pako",
-    "sommerfeldio"
+    "sommerfeldio",
+    "Structurizr"
   ],
   "asciidoc.antora.enableAntoraSupport": true,
   "yaml.schemas": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,13 @@
 {
-  "cSpell.words": ["brotli", "commitlint", "exitcode", "krokidile", "pako", "sommerfeldio"],
+  "cSpell.words": [
+    "brotli",
+    "commitlint",
+    "DITAA",
+    "exitcode",
+    "krokidile",
+    "pako",
+    "sommerfeldio"
+  ],
   "asciidoc.antora.enableAntoraSupport": true,
   "yaml.schemas": {
     "https://json.schemastore.org/yamllint.json": [

--- a/README.adoc
+++ b/README.adoc
@@ -28,8 +28,14 @@ Krokidile provides a web-based live editor for diagrams, enabling developers to 
 * Export diagrams as PNG or SVG image
 * Save the diagram code as a file
 * Supported diagram types
+** BlockDiag
+** Ditaa
 ** C4 with PlantUML
+** Erd (Entity-Relationship Diagram)
+** Mermaid
 ** PlantUML
+** RackDiag
+** Structurizr
 // (see https://kroki.io)
 // * Configure Krokidile to use your own Kroki instance (e.g., for self-hosting or to ensure your diagram data is kept private)
 

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,7 +1,7 @@
 ---
 name: public
 title: krokidile
-version: main
+version: diagram-types
 start_page: ROOT:index.adoc
 nav:
   - modules/ROOT/nav.adoc

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -28,8 +28,14 @@ Krokidile provides a web-based live editor for diagrams, enabling developers to 
 * Export diagrams as PNG or SVG image
 * Save the diagram code as a file
 * Supported diagram types
+** BlockDiag
+** Ditaa
 ** C4 with PlantUML
+** Erd (Entity-Relationship Diagram)
+** Mermaid
 ** PlantUML
+** RackDiag
+** Structurizr
 // (see https://kroki.io)
 // * Configure Krokidile to use your own Kroki instance (e.g., for self-hosting or to ensure your diagram data is kept private)
 

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -101,36 +101,21 @@ The Frontend is built with React on top of Node.js. The Backend is a Kroki insta
 
 The Application consists of the following components:
 
-[plantuml, puml-build-image, svg]
+[ditaa, "ditaa-diagram"]
 ----
-@startuml
-
-skinparam linetype ortho
-skinparam monochrome false
-skinparam componentStyle uml2
-skinparam backgroundColor transparent
-skinparam NoteBackgroundColor #eee
-skinparam activity {
-    'FontName Ubuntu
-    FontName Roboto
-}
-
-actor User
-component kroki as "Kroki Server" <<Service>>
-note bottom of kroki: https://kroki.io
-
-rectangle dc as "Docker Compose Stack" {
-    component app as "Krokidile App" <<NodeJS>>
-    component docs as "Krokidile Docs" <<Antora>>
-}
-
-User -right-> app
-app -right-> kroki
-
-User -right-> docs
-docs -[hidden]up-> app
-
-@enduml
++------+      +-----------------+
+| User |      |  Docker Compose |
++--+---+      |                 |
+   |          |   +-----------+ |      +--------+
+   |          |   | Krokidile | |      | Kroki  |
+   +------------->|    App    +------->| Server |
+   |          |   +-----------+ |      +--------+
+   |          |                 |
+   |          |   +-----------+ |
+   |          |   | Krokidile | |
+   +------------->|    App    | |
+              |   +-----------+ |
+              +-----------------+
 ----
 
 The Docker Compose stacks from this repo feature some additional components that are not part of the application itself but are required to run some linting tasks etc. Because they are not part of the actual application, they are not listed here.

--- a/src/diagram-type-data.js
+++ b/src/diagram-type-data.js
@@ -31,3 +31,13 @@ System(systemAlias, "Label", "Optional Description")
 Rel(personAlias, containerAlias, "Label", "Optional Technology")
 @enduml
 `;
+
+export const DITAA_ENDPOINT = 'ditaa';
+export const DITAA_EDITOR_LANGUAGE = 'plaintext';
+export const DITAA_MARKUP = `
++------+    +-------+
+|      |    |       |
+| Some +----+ Stuff |
+|      |    |       |
++------+    +-------+
+`;

--- a/src/diagram-type-data.js
+++ b/src/diagram-type-data.js
@@ -53,8 +53,24 @@ export const BLOCKDIAG_EDITOR_LANGUAGE = 'plaintext';
 export const BLOCKDIAG_MARKUP = `blockdiag {
     blockdiag -> generates -> "block-diagrams";
     blockdiag -> is -> "very easy!";
-  
+
     blockdiag [color = "greenyellow"];
     "block-diagrams" [color = "pink"];
     "very easy!" [color = "orange"];
 }`;
+
+// ------------------------------------------------------------------------------------------------
+
+export const ERD_ENDPOINT = 'erd';
+export const ERD_EDITOR_LANGUAGE = 'plaintext';
+export const ERD_MARKUP = `[Person]
+*name
++birth_location_id
+
+[Location]
+*id
+city
+state
+country
+
+Person *--1 Location`;

--- a/src/diagram-type-data.js
+++ b/src/diagram-type-data.js
@@ -19,6 +19,8 @@ User -right-> Component
 @enduml
 `;
 
+// ------------------------------------------------------------------------------------------------
+
 export const C4PUML_ENDPOINT = 'c4plantuml';
 export const C4PUML_EDITOR_LANGUAGE = PUML_ENDPOINT;
 export const C4PUML_MARKUP = `@startuml C4_Elements
@@ -32,6 +34,8 @@ Rel(personAlias, containerAlias, "Label", "Optional Technology")
 @enduml
 `;
 
+// ------------------------------------------------------------------------------------------------
+
 export const DITAA_ENDPOINT = 'ditaa';
 export const DITAA_EDITOR_LANGUAGE = 'plaintext';
 export const DITAA_MARKUP = `
@@ -41,3 +45,16 @@ export const DITAA_MARKUP = `
 |      |    |       |
 +------+    +-------+
 `;
+
+// ------------------------------------------------------------------------------------------------
+
+export const BLOCKDIAG_ENDPOINT = 'blockdiag';
+export const BLOCKDIAG_EDITOR_LANGUAGE = 'plaintext';
+export const BLOCKDIAG_MARKUP = `blockdiag {
+    blockdiag -> generates -> "block-diagrams";
+    blockdiag -> is -> "very easy!";
+  
+    blockdiag [color = "greenyellow"];
+    "block-diagrams" [color = "pink"];
+    "very easy!" [color = "orange"];
+}`;

--- a/src/diagram-type-data.js
+++ b/src/diagram-type-data.js
@@ -88,7 +88,6 @@ export const RACKDIAG_MARKUP = `rackdiag {
   7: Load Balancer;
 }`;
 
-
 // ------------------------------------------------------------------------------------------------
 
 export const MERMAID_ENDPOINT = 'mermaid';
@@ -104,4 +103,28 @@ export const MERMAID_MARKUP = `sequenceDiagram
     John-->Alice: Great!
     John->Bob: How about you?
     Bob-->John: Jolly good!
+`;
+
+
+// ------------------------------------------------------------------------------------------------
+
+export const STRUCTURIZR_ENDPOINT = 'structurizr';
+export const STRUCTURIZR_EDITOR_LANGUAGE = 'plaintext';
+export const STRUCTURIZR_MARKUP = `workspace {
+
+    model {
+        u = person "User"
+        ss = softwareSystem "Software System"
+
+        u -> ss "Uses"
+    }
+
+    views {
+        systemContext ss {
+            include *
+            autolayout lr
+        }
+    }
+    
+}
 `;

--- a/src/diagram-type-data.js
+++ b/src/diagram-type-data.js
@@ -87,3 +87,21 @@ export const RACKDIAG_MARKUP = `rackdiag {
   5: Web Server;
   7: Load Balancer;
 }`;
+
+
+// ------------------------------------------------------------------------------------------------
+
+export const MERMAID_ENDPOINT = 'mermaid';
+export const MERMAID_EDITOR_LANGUAGE = 'plaintext';
+export const MERMAID_MARKUP = `sequenceDiagram
+    participant Alice
+    participant Bob
+    Alice->John: Hello John, how are you?
+    loop Healthcheck
+        John->John: Fight against hypochondria
+    end
+    Note right of John: Rational thoughts prevail...
+    John-->Alice: Great!
+    John->Bob: How about you?
+    Bob-->John: Jolly good!
+`;

--- a/src/diagram-type-data.js
+++ b/src/diagram-type-data.js
@@ -105,7 +105,6 @@ export const MERMAID_MARKUP = `sequenceDiagram
     Bob-->John: Jolly good!
 `;
 
-
 // ------------------------------------------------------------------------------------------------
 
 export const STRUCTURIZR_ENDPOINT = 'structurizr';
@@ -125,6 +124,6 @@ export const STRUCTURIZR_MARKUP = `workspace {
             autolayout lr
         }
     }
-    
+
 }
 `;

--- a/src/diagram-type-data.js
+++ b/src/diagram-type-data.js
@@ -75,7 +75,6 @@ country
 
 Person *--1 Location`;
 
-
 // ------------------------------------------------------------------------------------------------
 
 export const RACKDIAG_ENDPOINT = 'rackdiag';

--- a/src/diagram-type-data.js
+++ b/src/diagram-type-data.js
@@ -74,3 +74,17 @@ state
 country
 
 Person *--1 Location`;
+
+
+// ------------------------------------------------------------------------------------------------
+
+export const RACKDIAG_ENDPOINT = 'rackdiag';
+export const RACKDIAG_EDITOR_LANGUAGE = 'plaintext';
+export const RACKDIAG_MARKUP = `rackdiag {
+  16U;
+  1: UPS [2U];
+  3: Web Server;
+  4: Web Server;
+  5: Web Server;
+  7: Load Balancer;
+}`;

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,9 @@ if (SELECTED_DIAGRAM_TYPE === diagramTypes.PUML_ENDPOINT) {
 } else if (SELECTED_DIAGRAM_TYPE === diagramTypes.DITAA_ENDPOINT) {
   DEFAULT_EDITOR_CONTENT = diagramTypes.DITAA_MARKUP;
   DEFAULT_EDITOR_LANGUAGE = diagramTypes.DITAA_EDITOR_LANGUAGE;
+} else if (SELECTED_DIAGRAM_TYPE === diagramTypes.BLOCKDIAG_ENDPOINT) {
+  DEFAULT_EDITOR_CONTENT = diagramTypes.BLOCKDIAG_MARKUP;
+  DEFAULT_EDITOR_LANGUAGE = diagramTypes.BLOCKDIAG_EDITOR_LANGUAGE;
 }
 
 //
@@ -49,8 +52,9 @@ if (SELECTED_DIAGRAM_TYPE === diagramTypes.PUML_ENDPOINT) {
   const extension = new PUmlExtension();
   const disposer = extension.active(editor);
 } else if (SELECTED_DIAGRAM_TYPE === diagramTypes.DITAA_ENDPOINT) {
-  const extension = new PUmlExtension();
-  const disposer = extension.active(editor);
+  // nothing yet
+} else if (SELECTED_DIAGRAM_TYPE === diagramTypes.BLOCKDIAG_ENDPOINT) {
+  // nothing yet
 }
 
 //
@@ -193,6 +197,7 @@ document.addEventListener('keydown', function (event) {
 function DiagramTypeSelector() {
   return (
     <div>
+      <DiagramTypeRadio id={`${diagramTypes.BLOCKDIAG_ENDPOINT}`} label="BlockDiag" />
       <DiagramTypeRadio id={`${diagramTypes.C4PUML_ENDPOINT}`} label="C4 PlantUML" />
       <DiagramTypeRadio id={`${diagramTypes.DITAA_ENDPOINT}`} label="Ditaa" />
       <DiagramTypeRadio id={`${diagramTypes.PUML_ENDPOINT}`} label="PlantUML" />

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,9 @@ if (SELECTED_DIAGRAM_TYPE === diagramTypes.PUML_ENDPOINT) {
 } else if (SELECTED_DIAGRAM_TYPE === diagramTypes.ERD_ENDPOINT) {
   DEFAULT_EDITOR_CONTENT = diagramTypes.ERD_MARKUP;
   DEFAULT_EDITOR_LANGUAGE = diagramTypes.ERD_EDITOR_LANGUAGE;
+} else if (SELECTED_DIAGRAM_TYPE === diagramTypes.RACKDIAG_ENDPOINT) {
+  DEFAULT_EDITOR_CONTENT = diagramTypes.RACKDIAG_MARKUP;
+  DEFAULT_EDITOR_LANGUAGE = diagramTypes.RACKDIAG_EDITOR_LANGUAGE;
 }
 
 //
@@ -59,6 +62,8 @@ if (SELECTED_DIAGRAM_TYPE === diagramTypes.PUML_ENDPOINT) {
 } else if (SELECTED_DIAGRAM_TYPE === diagramTypes.BLOCKDIAG_ENDPOINT) {
   // nothing yet
 } else if (SELECTED_DIAGRAM_TYPE === diagramTypes.ERD_ENDPOINT) {
+  // nothing yet
+} else if (SELECTED_DIAGRAM_TYPE === diagramTypes.RACKDIAG_ENDPOINT) {
   // nothing yet
 }
 
@@ -207,6 +212,7 @@ function DiagramTypeSelector() {
       <DiagramTypeRadio id={`${diagramTypes.DITAA_ENDPOINT}`} label="Ditaa" />
       <DiagramTypeRadio id={`${diagramTypes.ERD_ENDPOINT}`} label="Erd" />
       <DiagramTypeRadio id={`${diagramTypes.PUML_ENDPOINT}`} label="PlantUML" />
+      <DiagramTypeRadio id={`${diagramTypes.RACKDIAG_ENDPOINT}`} label="RackDiag" />
     </div>
   );
 }

--- a/src/index.js
+++ b/src/index.js
@@ -17,10 +17,17 @@ const SELECTED_DIAGRAM_TYPE =
 
 // Set the default content for the editor based on the selected diagram type.
 var DEFAULT_EDITOR_CONTENT = diagramTypes.PUML_MARKUP;
+var DEFAULT_EDITOR_LANGUAGE = diagramTypes.PUML_EDITOR_LANGUAGE;
+
 if (SELECTED_DIAGRAM_TYPE === diagramTypes.PUML_ENDPOINT) {
   DEFAULT_EDITOR_CONTENT = diagramTypes.PUML_MARKUP;
+  DEFAULT_EDITOR_LANGUAGE = diagramTypes.PUML_EDITOR_LANGUAGE;
 } else if (SELECTED_DIAGRAM_TYPE === diagramTypes.C4PUML_ENDPOINT) {
   DEFAULT_EDITOR_CONTENT = diagramTypes.C4PUML_MARKUP;
+  DEFAULT_EDITOR_LANGUAGE = diagramTypes.C4PUML_EDITOR_LANGUAGE;
+} else if (SELECTED_DIAGRAM_TYPE === diagramTypes.DITAA_ENDPOINT) {
+  DEFAULT_EDITOR_CONTENT = diagramTypes.DITAA_MARKUP;
+  DEFAULT_EDITOR_LANGUAGE = diagramTypes.DITAA_EDITOR_LANGUAGE;
 }
 
 //
@@ -30,7 +37,7 @@ if (SELECTED_DIAGRAM_TYPE === diagramTypes.PUML_ENDPOINT) {
 //
 const editor = monaco.editor.create(document.getElementById('editor'), {
   value: localStorage.getItem('editorContent') || DEFAULT_EDITOR_CONTENT,
-  language: diagramTypes.PUML_EDITOR_LANGUAGE,
+  language: DEFAULT_EDITOR_LANGUAGE,
   theme: 'vs-dark',
 });
 
@@ -39,6 +46,9 @@ if (SELECTED_DIAGRAM_TYPE === diagramTypes.PUML_ENDPOINT) {
   const extension = new PUmlExtension();
   const disposer = extension.active(editor);
 } else if (SELECTED_DIAGRAM_TYPE === diagramTypes.C4PUML_ENDPOINT) {
+  const extension = new PUmlExtension();
+  const disposer = extension.active(editor);
+} else if (SELECTED_DIAGRAM_TYPE === diagramTypes.DITAA_ENDPOINT) {
   const extension = new PUmlExtension();
   const disposer = extension.active(editor);
 }
@@ -112,7 +122,7 @@ ReactDOM.createRoot(document.getElementById('actions-menu')).render(<ActionsMenu
 // Download the contents of the editor as text file.
 //
 function downloadCode() {
-  const fileName = 'code.puml';
+  const fileName = 'code.txt';
   const diagramCode = editor.getValue();
   const blob = new Blob([diagramCode], { type: 'text/plain' });
   const url = URL.createObjectURL(blob);
@@ -126,7 +136,7 @@ function downloadSvg() {
   const fileName = 'diagram.svg';
   const diagramCode = editor.getValue();
 
-  fetch(`${KROKI_URL}/plantuml/svg/${encodeDiagramCode(diagramCode)}`)
+  fetch(`${KROKI_URL}/${SELECTED_DIAGRAM_TYPE}/svg/${encodeDiagramCode(diagramCode)}`)
     .then((response) => response.text())
     .then((svgResult) => {
       const blob = new Blob([svgResult], { type: 'image/svg+xml' });
@@ -145,7 +155,7 @@ function downloadPng() {
   const fileName = 'diagram.png';
   const diagramCode = editor.getValue();
 
-  fetch(`${KROKI_URL}/plantuml/png/${encodeDiagramCode(diagramCode)}`)
+  fetch(`${KROKI_URL}/${SELECTED_DIAGRAM_TYPE}/png/${encodeDiagramCode(diagramCode)}`)
     .then((response) => response.blob())
     .then((pngResult) => {
       const url = URL.createObjectURL(pngResult);
@@ -183,8 +193,9 @@ document.addEventListener('keydown', function (event) {
 function DiagramTypeSelector() {
   return (
     <div>
-      <DiagramTypeRadio id="c4plantuml" label="C4 PlantUML" />
-      <DiagramTypeRadio id="plantuml" label="PlantUML" />
+      <DiagramTypeRadio id={`${diagramTypes.C4PUML_ENDPOINT}`} label="C4 PlantUML" />
+      <DiagramTypeRadio id={`${diagramTypes.DITAA_ENDPOINT}`} label="Ditaa" />
+      <DiagramTypeRadio id={`${diagramTypes.PUML_ENDPOINT}`} label="PlantUML" />
     </div>
   );
 }

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,9 @@ if (SELECTED_DIAGRAM_TYPE === diagramTypes.PUML_ENDPOINT) {
 } else if (SELECTED_DIAGRAM_TYPE === diagramTypes.BLOCKDIAG_ENDPOINT) {
   DEFAULT_EDITOR_CONTENT = diagramTypes.BLOCKDIAG_MARKUP;
   DEFAULT_EDITOR_LANGUAGE = diagramTypes.BLOCKDIAG_EDITOR_LANGUAGE;
+} else if (SELECTED_DIAGRAM_TYPE === diagramTypes.ERD_ENDPOINT) {
+  DEFAULT_EDITOR_CONTENT = diagramTypes.ERD_MARKUP;
+  DEFAULT_EDITOR_LANGUAGE = diagramTypes.ERD_EDITOR_LANGUAGE;
 }
 
 //
@@ -54,6 +57,8 @@ if (SELECTED_DIAGRAM_TYPE === diagramTypes.PUML_ENDPOINT) {
 } else if (SELECTED_DIAGRAM_TYPE === diagramTypes.DITAA_ENDPOINT) {
   // nothing yet
 } else if (SELECTED_DIAGRAM_TYPE === diagramTypes.BLOCKDIAG_ENDPOINT) {
+  // nothing yet
+} else if (SELECTED_DIAGRAM_TYPE === diagramTypes.ERD_ENDPOINT) {
   // nothing yet
 }
 
@@ -200,6 +205,7 @@ function DiagramTypeSelector() {
       <DiagramTypeRadio id={`${diagramTypes.BLOCKDIAG_ENDPOINT}`} label="BlockDiag" />
       <DiagramTypeRadio id={`${diagramTypes.C4PUML_ENDPOINT}`} label="C4 PlantUML" />
       <DiagramTypeRadio id={`${diagramTypes.DITAA_ENDPOINT}`} label="Ditaa" />
+      <DiagramTypeRadio id={`${diagramTypes.ERD_ENDPOINT}`} label="Erd" />
       <DiagramTypeRadio id={`${diagramTypes.PUML_ENDPOINT}`} label="PlantUML" />
     </div>
   );

--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,9 @@ if (SELECTED_DIAGRAM_TYPE === diagramTypes.PUML_ENDPOINT) {
 } else if (SELECTED_DIAGRAM_TYPE === diagramTypes.MERMAID_ENDPOINT) {
   DEFAULT_EDITOR_CONTENT = diagramTypes.MERMAID_MARKUP;
   DEFAULT_EDITOR_LANGUAGE = diagramTypes.MERMAID_EDITOR_LANGUAGE;
+} else if (SELECTED_DIAGRAM_TYPE === diagramTypes.STRUCTURIZR_ENDPOINT) {
+  DEFAULT_EDITOR_CONTENT = diagramTypes.STRUCTURIZR_MARKUP;
+  DEFAULT_EDITOR_LANGUAGE = diagramTypes.STRUCTURIZR_EDITOR_LANGUAGE;
 }
 
 //
@@ -69,6 +72,8 @@ if (SELECTED_DIAGRAM_TYPE === diagramTypes.PUML_ENDPOINT) {
 } else if (SELECTED_DIAGRAM_TYPE === diagramTypes.RACKDIAG_ENDPOINT) {
   // nothing yet
 } else if (SELECTED_DIAGRAM_TYPE === diagramTypes.MERMAID_ENDPOINT) {
+  // nothing yet
+} else if (SELECTED_DIAGRAM_TYPE === diagramTypes.STRUCTURIZR_ENDPOINT) {
   // nothing yet
 }
 
@@ -219,6 +224,7 @@ function DiagramTypeSelector() {
       <DiagramTypeRadio id={`${diagramTypes.MERMAID_ENDPOINT}`} label="Mermaid" />
       <DiagramTypeRadio id={`${diagramTypes.PUML_ENDPOINT}`} label="PlantUML" />
       <DiagramTypeRadio id={`${diagramTypes.RACKDIAG_ENDPOINT}`} label="RackDiag" />
+      <DiagramTypeRadio id={`${diagramTypes.STRUCTURIZR_ENDPOINT}`} label="Structurizr" />
     </div>
   );
 }

--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,9 @@ if (SELECTED_DIAGRAM_TYPE === diagramTypes.PUML_ENDPOINT) {
 } else if (SELECTED_DIAGRAM_TYPE === diagramTypes.RACKDIAG_ENDPOINT) {
   DEFAULT_EDITOR_CONTENT = diagramTypes.RACKDIAG_MARKUP;
   DEFAULT_EDITOR_LANGUAGE = diagramTypes.RACKDIAG_EDITOR_LANGUAGE;
+} else if (SELECTED_DIAGRAM_TYPE === diagramTypes.MERMAID_ENDPOINT) {
+  DEFAULT_EDITOR_CONTENT = diagramTypes.MERMAID_MARKUP;
+  DEFAULT_EDITOR_LANGUAGE = diagramTypes.MERMAID_EDITOR_LANGUAGE;
 }
 
 //
@@ -64,6 +67,8 @@ if (SELECTED_DIAGRAM_TYPE === diagramTypes.PUML_ENDPOINT) {
 } else if (SELECTED_DIAGRAM_TYPE === diagramTypes.ERD_ENDPOINT) {
   // nothing yet
 } else if (SELECTED_DIAGRAM_TYPE === diagramTypes.RACKDIAG_ENDPOINT) {
+  // nothing yet
+} else if (SELECTED_DIAGRAM_TYPE === diagramTypes.MERMAID_ENDPOINT) {
   // nothing yet
 }
 
@@ -211,6 +216,7 @@ function DiagramTypeSelector() {
       <DiagramTypeRadio id={`${diagramTypes.C4PUML_ENDPOINT}`} label="C4 PlantUML" />
       <DiagramTypeRadio id={`${diagramTypes.DITAA_ENDPOINT}`} label="Ditaa" />
       <DiagramTypeRadio id={`${diagramTypes.ERD_ENDPOINT}`} label="Erd" />
+      <DiagramTypeRadio id={`${diagramTypes.MERMAID_ENDPOINT}`} label="Mermaid" />
       <DiagramTypeRadio id={`${diagramTypes.PUML_ENDPOINT}`} label="PlantUML" />
       <DiagramTypeRadio id={`${diagramTypes.RACKDIAG_ENDPOINT}`} label="RackDiag" />
     </div>


### PR DESCRIPTION
This pull request introduces support for rendering and previewing various types of diagrams through integration with a Kroki instance. The following diagram types are now supported:

- https://github.com/sommerfeld-io/krokidile/issues/71: Diagrams Through Ascii Art
- https://github.com/sommerfeld-io/krokidile/issues/60: Block diagrams
- https://github.com/sommerfeld-io/krokidile/issues/72: Entity-Relationship diagrams
- https://github.com/sommerfeld-io/krokidile/issues/67: Rack diagrams
- https://github.com/sommerfeld-io/krokidile/issues/75: Diagrams and visualizations with Markdown-like syntax
- https://github.com/sommerfeld-io/krokidile/issues/78: C4 model diagrams for software architecture

### Features
- Rendering and Previewing:
    - For each diagram type, the code is sent to a Kroki instance.
    - The rendered diagrams are previewed as images directly within the application interface.
- Download Support:
    - Users can download the source code for each diagram type.
    - Users can also download the rendered images of the diagrams.

The integration ensures that users can easily create, preview, and download both the code and the resulting images of the diagrams, enhancing the overall user experience and productivity in diagram creation and management.